### PR TITLE
Explain legacy classification for string ref attributes

### DIFF
--- a/docs/docs/08.1-more-about-refs.md
+++ b/docs/docs/08.1-more-about-refs.md
@@ -68,7 +68,7 @@ Note that when the referenced component is unmounted and whenever the ref change
 
 ## The ref String Attribute
 
-React also supports using a string (instead of a callback) as a ref prop on any component, although this approach is mostly legacy at this point.
+React also supports using a string (instead of a callback) as a ref prop on any component, although this approach is mostly legacy at this point (we prefer callback refs over string refs - see [#4964](https://github.com/facebook/react/pull/4964#commitcomment-14341707)).
 
 1. Assign a `ref` attribute to anything returned from `render` such as:
 


### PR DESCRIPTION
In reference to this confusion: https://github.com/facebook/react/pull/4964#commitcomment-14341707

CC @jimfb
